### PR TITLE
Add combined crypt-villus gradient analysis script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # organoid_atlas
+
+This repository contains a MATLAB pipeline for analysing crypt-to-villus
+cell gradients. The combined script `crypt_to_villus_gradients_combined.m`
+allows interactive processing of CSV files with cell measurements and
+produces gradient summaries for the metrics **MeanInt**, **MeanTauPhase**
+and **MeanTauModulation**.
+
+Run the script in MATLAB and follow on-screen prompts to select your files
+and define the crypt and villus reference cells. Results and figures are
+saved under `./output/<Metric>/` for each metric, including a pooled mean ± SEM
+curve and a combined single-cell heatmap.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ Run the script in MATLAB and follow on-screen prompts to select your files
 and define the crypt and villus reference cells. Results and figures are
 saved under `./output/<Metric>/` for each metric, including a pooled mean ± SEM
 curve and a combined single-cell heatmap.
+
+For FLIM CSVs with columns `Int`, `TauPhase`, `TauModulation`, `Xcoord`, and
+`Ycoord`, the helper `crypt_to_villus_gradients_from_IntTau.m` lets you choose
+the crypt→villus axis separately for each file (via two clicks per sample)
+and outputs pooled Int/TauPhase/TauModulation mean ± SEM curves. The plotted
+curves include light smoothing for display while the exported CSV retains the
+unsmoothed bin statistics.

--- a/crypt_to_villus_gradients_combined.m
+++ b/crypt_to_villus_gradients_combined.m
@@ -1,0 +1,272 @@
+function crypt_to_villus_gradients_combined
+%CRYPTO_VILLUS_GRADIENTS_COMBINED Interactive analysis for multiple metrics.
+%   Combines previous standalone scripts for MeanInt, MeanTauPhase and
+%   MeanTauModulation into one pipeline. Users select CSV files containing
+%   per-cell measurements and define the crypt base and villus tip cells.
+%   The function computes normalized positions along the crypt->villus axis
+%   and generates summaries and plots (pooled mean ± SEM and combined
+%   single-cell heatmap) for each metric.
+%
+%   Output structure:
+%     ./output/<Metric>/ ... files and figures for each metric.
+%
+%   Expected input columns in each CSV:
+%       Id, CentroidX, CentroidY, MeanInt, MeanTauPhase, MeanTauModulation
+%
+%   Example:
+%       crypt_to_villus_gradients_combined
+%
+% Author: OpenAI Assistant
+
+%% --------------------- USER SETTINGS ---------------------
+numBins        = 50;
+pctList        = [10 25 50 75 90];
+outFolder      = './output';
+lowessSpan     = 0.2;
+
+if ~exist(outFolder,'dir'), mkdir(outFolder); end
+
+%% Metrics to analyse
+metrics = {
+    struct('field','MeanInt',         'label','Mean intensity');
+    struct('field','MeanTauPhase',    'label','MeanTauPhase');
+    struct('field','MeanTauModulation','label','MeanTauModulation')
+    };
+
+%% --------------------- SELECT FILES + AXES ---------------------
+[fileList, axisDef] = chooseFilesAndAxes();
+if isempty(fileList), disp('No files selected. Exiting.'); return; end
+
+%% --------------------- PROCESS SAMPLES (projection only) ---------------------
+numFiles = numel(fileList);
+tables = cell(numFiles,1);
+sampleNames = cell(numFiles,1);
+
+% Expand required metric fields
+req = [{'Id','CentroidX','CentroidY'}];
+for m = 1:numel(metrics)
+    req{end+1} = metrics{m}.field; %#ok<AGROW>
+end
+
+for k = 1:numFiles
+    fpath = fileList{k};
+    [~,fname,ext] = fileparts(fpath);
+    sampleName = [fname ext];
+    T = readtable(fpath);
+
+    assert(all(ismember(req, T.Properties.VariableNames)), ...
+        'File %s must contain columns: %s', fpath, strjoin(req, ', '));
+
+    cryptId  = axisDef{k}.cryptId;
+    villusId = axisDef{k}.villusId;
+    [baseXY, tipXY] = getAxisFromIds(T, cryptId, villusId);
+
+    v = (tipXY - baseXY);
+    vlen2 = sum(v.^2);
+    assert(vlen2 > 0, 'Chosen crypt and villus points are identical for %s', sampleName);
+
+    pts = [T.CentroidX, T.CentroidY];
+    proj = ((pts - baseXY) * v.') / vlen2;
+    proj01 = min(max(proj,0),1);
+
+    edges = linspace(0,1,numBins+1);
+    [~,~,binIdx] = histcounts(proj01, edges);
+
+    T.Sample = repmat(string(sampleName), height(T), 1);
+    T.Proj01 = proj01;
+    T.Bin    = binIdx;
+
+    tables{k} = T;
+    sampleNames{k} = sampleName;
+end
+
+%% --------------------- ANALYSIS PER METRIC ---------------------
+edges = linspace(0,1,numBins+1);
+binCenters = edges(1:end-1) + diff(edges)/2;
+
+for m = 1:numel(metrics)
+    metric = metrics{m};
+    subOut = fullfile(outFolder, metric.field);
+    if ~exist(subOut,'dir'), mkdir(subOut); end
+
+    allRows = table();
+    perSampleSummary = table();
+
+    for k = 1:numFiles
+        T = tables{k};
+        sampleName = sampleNames{k};
+        allRows = [allRows; T(:, {'Sample','Id','Proj01','Bin', metric.field})]; %#ok<AGROW>
+
+        S = summarizeBins(T, binCenters, pctList, metric.field);
+        S.Sample = repmat(string(sampleName), height(S), 1);
+        perSampleSummary = [perSampleSummary; S]; %#ok<AGROW>
+
+        [~,ord] = sort(T.Proj01);
+
+        sampleTableOrdered = table(T.Id(ord), T.Proj01(ord), T.(metric.field)(ord), ...
+            'VariableNames', {'Id','Proj01', metric.field});
+        writetable(sampleTableOrdered, fullfile(subOut, sprintf('heatmap_%s_ordered.csv', matlab.lang.makeValidName(sampleName))));
+    end
+
+    writetable(allRows, fullfile(subOut,'all_cells_with_projection.csv'));
+    writetable(perSampleSummary, fullfile(subOut,'bin_summary_per_sample.csv'));
+
+    overall = summarizeBins(allRows, binCenters, pctList, metric.field);
+    writetable(overall, fullfile(subOut,'bin_summary_overall.csv'));
+
+
+    [~, ordAll] = sort(allRows.Proj01);
+    heat_all = table(allRows.Sample(ordAll), allRows.Id(ordAll), allRows.Proj01(ordAll), allRows.(metric.field)(ordAll), ...
+        'VariableNames', {'Sample','Id','Proj01', metric.field});
+    writetable(heat_all, fullfile(subOut,'heatmap_allcells_ordered.csv'));
+
+    lowessX = overall.BinCenter;
+    lowessY = overall.Median;
+    smY = smooth(lowessX, lowessY, lowessSpan, 'lowess');
+    lowessT = table(lowessX, smY, 'VariableNames', {'BinCenter','SmoothedMedian'});
+    writetable(lowessT, fullfile(subOut,'lowess_smoothed.csv'));
+
+    makePlotsAndHeatmaps(allRows, overall, subOut, metric.field, metric.label);
+end
+end
+
+%% --------------------- INTERACTIVE FILE + AXIS SELECTION ---------------------
+function [files, axisDef] = chooseFilesAndAxes()
+    [fn,pth] = uigetfile('*.csv','Select CSV files','MultiSelect','on');
+    if isequal(fn,0), files={}; axisDef={}; return; end
+    if ischar(fn), fn={fn}; end
+    files = fullfile(pth, fn);
+    axisDef = cell(numel(files),1);
+    for k=1:numel(files)
+        T = readtable(files{k});
+        [~,basename,ext] = fileparts(files{k});
+        sampName = [basename ext];
+        fprintf('\n--- File %d: %s ---\n', k, sampName);
+        previewTbl = T(1:min(height(T),30), {'Id','CentroidX','CentroidY'});
+        disp(previewTbl);
+        cryptId = input(sprintf('Enter crypt_base Id for %s: ', sampName));
+        villusId = input(sprintf('Enter villus_tip Id for %s: ', sampName));
+        if ~any(T.Id==cryptId), error('cryptId %d not found', cryptId); end
+        if ~any(T.Id==villusId), error('villusId %d not found', villusId); end
+        centroids=[T.CentroidX,T.CentroidY];
+        f = figure('Name',sprintf('Centroids preview: %s',sampName),'Color','w');
+        styleDefaults(f);
+        scatter(centroids(:,1),centroids(:,2),12,'k','filled'); hold on;
+        rC=T(T.Id==cryptId,:); rV=T(T.Id==villusId,:);
+        scatter(rC.CentroidX,rC.CentroidY,80,'b','filled','MarkerEdgeColor','w');
+        scatter(rV.CentroidX,rV.CentroidY,80,'r','filled','MarkerEdgeColor','w');
+        legend({'cells','crypt','villus'},'Box','off','Location','best');
+        axis equal; set(gca,'YDir','reverse');
+        title(sampName,'FontWeight','bold');
+        prismAxes(gca);
+        input('Press Enter to continue...','s'); close(f);
+        axisDef{k}=struct('cryptId',cryptId,'villusId',villusId);
+    end
+end
+
+%% --------------------- AXIS LOOKUP ---------------------
+function [baseXY, tipXY] = getAxisFromIds(T, cryptId, villusId)
+    rowC = T(T.Id==cryptId,:); rowV = T(T.Id==villusId,:);
+    baseXY=[rowC.CentroidX,rowC.CentroidY];
+    tipXY=[rowV.CentroidX,rowV.CentroidY];
+end
+
+%% --------------------- BIN SUMMARY ---------------------
+function S = summarizeBins(T, binCenters, pctList, fieldName)
+    numBins = numel(binCenters);
+    Mean=nan(numBins,1); SEM=nan(numBins,1); N=zeros(numBins,1);
+    Pcts=nan(numBins,numel(pctList));
+    for b=1:numBins
+        mask=(T.Bin==b); x=T.(fieldName)(mask); x=x(~isnan(x));
+        N(b)=numel(x);
+        if N(b)>0
+            Mean(b)=mean(x); SEM(b)=std(x)/sqrt(N(b));
+            Pcts(b,:)=prctile(x,pctList);
+        end
+    end
+    S=table((1:numBins).',binCenters(:),N(:),Mean(:),SEM(:), ...
+        'VariableNames',{'Bin','BinCenter','N','Mean','SEM'});
+    for i=1:numel(pctList)
+        S.(sprintf('P%02d',pctList(i)))=Pcts(:,i);
+    end
+    if any(strcmp('P50',S.Properties.VariableNames))
+        S.Median=S.P50; else S.Median=NaN(size(Mean)); end
+end
+
+%% --------------------- PLOTTING ---------------------
+function makePlotsAndHeatmaps(allRows, overall, outFolder, fieldName, fieldLabel)
+    [~,ordAll]=sort(allRows.Proj01); valsAll=allRows.(fieldName)(ordAll);
+    clim = prctile(valsAll,[5 95]);
+
+    %% 1) Mean + SEM (pooled; Prism-like)
+    f1 = figure('Color','w','Position',[200 200 1000 600]); styleDefaults(f1);
+    ax1 = axes('Parent',f1); hold(ax1,'on'); box(ax1,'off');
+    p = plot(ax1, overall.BinCenter, overall.Mean, 'k-', 'LineWidth', 2);
+    fb = fillBetween(ax1, overall.BinCenter, overall.Mean-overall.SEM, overall.Mean+overall.SEM, [0 0 0], 0.15);
+    uistack(fb,'bottom'); uistack(p,'top');
+    xlabel(ax1,'Normalized position (0 = crypt, 1 = villus)','FontWeight','bold');
+    ylabel(ax1,fieldLabel,'FontWeight','bold');
+    title(ax1,'Pooled mean ± SEM','FontWeight','bold');
+    prismAxes(ax1);
+    export600(f1, fullfile(outFolder,'fig_mean_sem.png'));
+
+    %% 2) Combined single-cell heatmap
+    f2 = figure('Color','w','Position',[200 200 1200 320]); styleDefaults(f2);
+    ax2 = axes('Parent',f2); hold(ax2,'on'); box(ax2,'off');
+    H = repmat(valsAll.',24,1);
+    imagesc(ax2, [0 1],[0 1], H);
+    set(ax2,'YTick',[],'YColor','none');
+    xlabel(ax2,'Normalized position (all samples)','FontWeight','bold');
+    title(ax2,['Single-cell ' fieldLabel ' (combined)'],'FontWeight','bold');
+    c = colorbar(ax2); ylabel(c,fieldLabel,'FontWeight','bold');
+    caxis(ax2,clim); colormap(ax2,parula);
+    prismAxes(ax2,true);
+    export600(f2, fullfile(outFolder,'fig_heatmap_allcells.png'));
+
+end
+
+%% --------------------- STYLING HELPERS ---------------------
+function styleDefaults(figHandle)
+    set(figHandle, ...
+        'DefaultAxesFontName','Arial', ...
+        'DefaultAxesFontSize',12, ...
+        'DefaultAxesFontWeight','bold', ...
+        'DefaultAxesLineWidth',2.5, ...
+        'DefaultAxesTickDir','out', ...
+        'DefaultAxesTickLength',[0.015 0.015], ...
+        'DefaultAxesBox','off', ...
+        'DefaultLineLineWidth',2, ...
+        'DefaultFigurePaperPositionMode','auto');
+end
+
+function prismAxes(ax, isHeatmap)
+    if nargin<2, isHeatmap=false; end
+    set(ax, 'Box','off', ...
+            'TickDir','out', ...
+            'LineWidth',2.5, ...
+            'FontWeight','bold', ...
+            'FontName','Arial', ...
+            'FontSize',12, ...
+            'Layer','top');
+    if isHeatmap
+        grid(ax,'off');
+        ax.LineWidth = 1.0;
+    end
+end
+
+function export600(figHandle, outPath)
+    [~,~,ext] = fileparts(outPath);
+    if isempty(ext), outPath = [outPath '.png']; end
+    try
+        exportgraphics(figHandle, outPath, 'Resolution', 600);
+    catch
+        print(figHandle, outPath, '-dpng', '-r600');
+    end
+end
+
+function h=fillBetween(ax,x,y1,y2,colorRGB,alphaVal)
+    x=x(:)'; y1=y1(:)'; y2=y2(:)';
+    hold(ax,'on');
+    h=fill(ax, [x fliplr(x)], [y1 fliplr(y2)], colorRGB, ...
+        'EdgeColor','none', 'FaceAlpha', alphaVal);
+end

--- a/crypt_to_villus_gradients_from_IntTau.m
+++ b/crypt_to_villus_gradients_from_IntTau.m
@@ -29,7 +29,7 @@ if ischar(files)
 end
 fileList = fullfile(pth, files);
 
-%% --------------------- LOAD & CONCATENATE ---------------------
+%% --------------------- LOAD, VALIDATE, AND GET AXIS PER FILE ---------------------
 requiredVars = {'Int','TauPhase','TauModulation','Xcoord','Ycoord'};
 allRows = table();
 for k = 1:numel(fileList)
@@ -38,7 +38,19 @@ for k = 1:numel(fileList)
     assert(all(ismember(requiredVars, T.Properties.VariableNames)), ...
         'File %s must contain columns: %s', fpath, strjoin(requiredVars, ', '));
     [~,fname,ext] = fileparts(fpath);
-    T.Sample = repmat(string([fname ext]), height(T), 1);
+    sampleName = string([fname ext]);
+
+    % Ask the user to pick crypt (first click) and villus (second click) for this sample.
+    [baseXY, tipXY] = getAxisFromClicks(T.Xcoord, T.Ycoord, sampleName);
+    v = tipXY - baseXY;
+    vlen2 = sum(v.^2);
+    assert(vlen2 > 0, 'Crypt and villus clicks are identical for sample %s.', sampleName);
+
+    pts = [T.Xcoord, T.Ycoord];
+    proj = ((pts - baseXY) * v.') / vlen2; % projection scalar
+    T.Pos01 = min(max(proj,0),1);          % clip to [0,1]
+
+    T.Sample = repmat(sampleName, height(T), 1);
     allRows = [allRows; T]; %#ok<AGROW>
 end
 
@@ -46,36 +58,6 @@ if isempty(allRows)
     disp('No data loaded. Exiting.');
     return;
 end
-
-%% --------------------- AXIS DEFINITION (USER CLICKS) ---------------------
-fScatter = figure('Color','w');
-scatter(allRows.Xcoord, allRows.Ycoord, 8, 'k', 'filled');
-axis equal;
-xlabel('Xcoord'); ylabel('Ycoord');
-title('Click crypt base (first) then villus tip (second)');
-set(gca,'FontName','Arial','FontWeight','bold','LineWidth',2,'TickDir','out');
-try
-    [xClick,yClick] = ginput(2);
-catch
-    close(fScatter);
-    error('Axis selection aborted.');
-end
-if numel(xClick) < 2
-    close(fScatter);
-    error('Two points are required to define the axis.');
-end
-baseXY = [xClick(1), yClick(1)]; % crypt
-tipXY  = [xClick(2), yClick(2)]; % villus
-close(fScatter);
-
-v = tipXY - baseXY;
-vlen2 = sum(v.^2);
-assert(vlen2 > 0, 'Crypt and villus clicks are identical.');
-
-pts = [allRows.Xcoord, allRows.Ycoord];
-proj = ((pts - baseXY) * v.') / vlen2; % projection scalar
-proj01 = min(max(proj,0),1);           % clip to [0,1]
-allRows.Pos01 = proj01;
 
 %% --------------------- BINNING ---------------------
 edges = linspace(0,1,numBins+1);
@@ -147,6 +129,30 @@ function S = computeBinStats(values, binIdx, numBins)
         end
     end
     S = struct('Mean',Mean,'SEM',SEM,'N',N);
+end
+
+function [baseXY, tipXY] = getAxisFromClicks(x, y, sampleName)
+%GETAXISFROMCLICKS Ask the user to click crypt then villus for one sample.
+    fScatter = figure('Color','w');
+    scatter(x, y, 8, 'k', 'filled');
+    axis equal;
+    xlabel('Xcoord'); ylabel('Ycoord');
+    title(sprintf('%s: click crypt base (first) then villus tip (second)', sampleName), ...
+        'Interpreter','none');
+    set(gca,'FontName','Arial','FontWeight','bold','LineWidth',2,'TickDir','out');
+    try
+        [xClick,yClick] = ginput(2);
+    catch
+        close(fScatter);
+        error('Axis selection aborted for sample %s.', sampleName);
+    end
+    if numel(xClick) < 2
+        close(fScatter);
+        error('Two points are required to define the axis for sample %s.', sampleName);
+    end
+    baseXY = [xClick(1), yClick(1)]; % crypt
+    tipXY  = [xClick(2), yClick(2)]; % villus
+    close(fScatter);
 end
 
 end

--- a/crypt_to_villus_gradients_from_IntTau.m
+++ b/crypt_to_villus_gradients_from_IntTau.m
@@ -1,0 +1,152 @@
+function crypt_to_villus_gradients_from_IntTau
+%CRYPT_TO_VILLUS_GRADIENTS_FROM_INTTAU Analyze crypt->villus gradients for Int/TauPhase/TauModulation.
+%   Interactively selects CSV files (one row per cell) with required columns:
+%   Int, TauPhase, TauModulation, Xcoord, Ycoord.
+%   The user defines the crypt-to-villus axis by clicking two points on a
+%   scatter plot (crypt first, villus second). The function projects all cells
+%   onto this axis, bins the normalized positions, computes pooled mean and
+%   SEM per bin for each metric, and saves a single Prism-like figure with
+%   the three pooled mean ± SEM curves plus a CSV summary of bin statistics.
+%
+%   Output directory: ./output_IntTau/
+%
+%   This function relies only on base MATLAB (R2021b+).
+
+%% --------------------- USER SETTINGS ---------------------
+numBins   = 50;         % number of bins between crypt (0) and villus (1)
+outFolder = './output_IntTau';
+
+if ~exist(outFolder,'dir'), mkdir(outFolder); end
+
+%% --------------------- FILE SELECTION ---------------------
+[files, pth] = uigetfile('*.csv','Select CSV files','MultiSelect','on');
+if isequal(files,0)
+    % user cancelled
+    return;
+end
+if ischar(files)
+    files = {files};
+end
+fileList = fullfile(pth, files);
+
+%% --------------------- LOAD & CONCATENATE ---------------------
+requiredVars = {'Int','TauPhase','TauModulation','Xcoord','Ycoord'};
+allRows = table();
+for k = 1:numel(fileList)
+    fpath = fileList{k};
+    T = readtable(fpath);
+    assert(all(ismember(requiredVars, T.Properties.VariableNames)), ...
+        'File %s must contain columns: %s', fpath, strjoin(requiredVars, ', '));
+    [~,fname,ext] = fileparts(fpath);
+    T.Sample = repmat(string([fname ext]), height(T), 1);
+    allRows = [allRows; T]; %#ok<AGROW>
+end
+
+if isempty(allRows)
+    disp('No data loaded. Exiting.');
+    return;
+end
+
+%% --------------------- AXIS DEFINITION (USER CLICKS) ---------------------
+fScatter = figure('Color','w');
+scatter(allRows.Xcoord, allRows.Ycoord, 8, 'k', 'filled');
+axis equal;
+xlabel('Xcoord'); ylabel('Ycoord');
+title('Click crypt base (first) then villus tip (second)');
+set(gca,'FontName','Arial','FontWeight','bold','LineWidth',2,'TickDir','out');
+try
+    [xClick,yClick] = ginput(2);
+catch
+    close(fScatter);
+    error('Axis selection aborted.');
+end
+if numel(xClick) < 2
+    close(fScatter);
+    error('Two points are required to define the axis.');
+end
+baseXY = [xClick(1), yClick(1)]; % crypt
+tipXY  = [xClick(2), yClick(2)]; % villus
+close(fScatter);
+
+v = tipXY - baseXY;
+vlen2 = sum(v.^2);
+assert(vlen2 > 0, 'Crypt and villus clicks are identical.');
+
+pts = [allRows.Xcoord, allRows.Ycoord];
+proj = ((pts - baseXY) * v.') / vlen2; % projection scalar
+proj01 = min(max(proj,0),1);           % clip to [0,1]
+allRows.Pos01 = proj01;
+
+%% --------------------- BINNING ---------------------
+edges = linspace(0,1,numBins+1);
+binCenters = edges(1:end-1) + diff(edges)/2;
+[~,~,binIdx] = histcounts(allRows.Pos01, edges);
+
+metrics = {'Int','TauPhase','TauModulation'};
+stats = struct();
+for i = 1:numel(metrics)
+    stats.(metrics{i}) = computeBinStats(allRows.(metrics{i}), binIdx, numBins);
+end
+
+%% --------------------- CSV SUMMARY ---------------------
+summaryTbl = table((1:numBins).', binCenters(:), ...
+    stats.Int.N(:), stats.Int.Mean(:), stats.Int.SEM(:), ...
+    stats.TauPhase.N(:), stats.TauPhase.Mean(:), stats.TauPhase.SEM(:), ...
+    stats.TauModulation.N(:), stats.TauModulation.Mean(:), stats.TauModulation.SEM(:), ...
+    'VariableNames', {'Bin','BinCenter', ...
+    'N_Int','Mean_Int','SEM_Int', ...
+    'N_TauPhase','Mean_TauPhase','SEM_TauPhase', ...
+    'N_TauModulation','Mean_TauModulation','SEM_TauModulation'});
+writetable(summaryTbl, fullfile(outFolder, 'pooled_bin_summary.csv'));
+
+%% --------------------- PLOT MEAN ± SEM ---------------------
+fFig = figure('Color','w','Position',[200 200 1200 500]);
+set(fFig,'DefaultAxesFontName','Arial', ...
+         'DefaultAxesFontSize',12, ...
+         'DefaultAxesFontWeight','bold', ...
+         'DefaultAxesLineWidth',2, ...
+         'DefaultAxesTickDir','out', ...
+         'DefaultAxesBox','off');
+
+ylabs = {'Intensity (a.u.)','TauPhase (ns)','TauModulation (ns)'};
+for i = 1:numel(metrics)
+    ax = subplot(1,3,i,'Parent',fFig); hold(ax,'on'); box(ax,'off');
+    m = stats.(metrics{i}).Mean;
+    s = stats.(metrics{i}).SEM;
+    fill(ax, [binCenters fliplr(binCenters)], [m-s; flipud(m+s)].', ...
+        [0 0 0], 'FaceAlpha',0.15, 'EdgeColor','none');
+    plot(ax, binCenters, m, 'k-', 'LineWidth',2);
+    xlabel(ax, 'Normalized position (0 = crypt, 1 = villus)');
+    ylabel(ax, ylabs{i});
+    title(ax, sprintf('Pooled %s mean \pm SEM', metrics{i}), 'Interpreter','none');
+    xlim(ax,[0 1]);
+end
+
+try
+    exportgraphics(fFig, fullfile(outFolder,'pooled_mean_sem.png'), 'Resolution', 600);
+catch
+    print(fFig, fullfile(outFolder,'pooled_mean_sem.png'), '-dpng','-r600');
+end
+
+end
+
+%% --------------------- HELPERS ---------------------
+function S = computeBinStats(values, binIdx, numBins)
+%COMPUTEBINSTATS Compute N, mean, and SEM per bin for a vector of values.
+    Mean = nan(numBins,1);
+    SEM  = nan(numBins,1);
+    N    = zeros(numBins,1);
+    for b = 1:numBins
+        mask = (binIdx == b);
+        x = values(mask);
+        x = x(~isnan(x));
+        N(b) = numel(x);
+        if N(b) > 0
+            Mean(b) = mean(x);
+            SEM(b)  = std(x) / sqrt(N(b));
+        end
+    end
+    S = struct('Mean',Mean,'SEM',SEM,'N',N);
+end
+
+end

--- a/crypt_to_villus_gradients_from_IntTau.m
+++ b/crypt_to_villus_gradients_from_IntTau.m
@@ -13,8 +13,9 @@ function crypt_to_villus_gradients_from_IntTau
 %   This function relies only on base MATLAB (R2021b+).
 
 %% --------------------- USER SETTINGS ---------------------
-numBins   = 50;         % number of bins between crypt (0) and villus (1)
-outFolder = './output_IntTau';
+numBins    = 50;         % number of bins between crypt (0) and villus (1)
+outFolder  = './output_IntTau';
+smoothSpan = 0.12;       % fraction of bins used for smoothing plotted curves
 
 if ~exist(outFolder,'dir'), mkdir(outFolder); end
 
@@ -93,8 +94,11 @@ set(fFig,'DefaultAxesFontName','Arial', ...
 ylabs = {'Intensity (a.u.)','TauPhase (ns)','TauModulation (ns)'};
 for i = 1:numel(metrics)
     ax = subplot(1,3,i,'Parent',fFig); hold(ax,'on'); box(ax,'off');
-    m = stats.(metrics{i}).Mean;
-    s = stats.(metrics{i}).SEM;
+    mRaw = stats.(metrics{i}).Mean;
+    sRaw = stats.(metrics{i}).SEM;
+    % Smooth only for visualization; CSV retains the raw bin statistics.
+    m = smoothForPlot(mRaw, smoothSpan);
+    s = smoothForPlot(sRaw, smoothSpan);
     fill(ax, [binCenters fliplr(binCenters)], [m-s; flipud(m+s)].', ...
         [0 0 0], 'FaceAlpha',0.15, 'EdgeColor','none');
     plot(ax, binCenters, m, 'k-', 'LineWidth',2);
@@ -153,6 +157,27 @@ function [baseXY, tipXY] = getAxisFromClicks(x, y, sampleName)
     baseXY = [xClick(1), yClick(1)]; % crypt
     tipXY  = [xClick(2), yClick(2)]; % villus
     close(fScatter);
+end
+
+function y = smoothForPlot(x, span)
+%SMOOTHFORPLOT Light smoothing helper for plotting jagged curves.
+%   Uses LOWESS via SMOOTHDATA when available; falls back to a moving mean.
+    if nargin < 2 || isempty(span)
+        span = 0.12;
+    end
+    y = x;
+    if isempty(x) || all(isnan(x))
+        return;
+    end
+    win = max(1, round(span * numel(x)));
+    if win < 2
+        return;
+    end
+    try
+        y = smoothdata(x, 'lowess', win, 'omitnan');
+    catch
+        y = movmean(x, win, 'omitnan');
+    end
 end
 
 end


### PR DESCRIPTION
## Summary
- add `crypt_to_villus_gradients_combined.m`, a unified MATLAB pipeline to analyze crypt→villus gradients for MeanInt, MeanTauPhase, and MeanTauModulation
- remove bin-averaged intensity heatmap, leaving pooled mean ± SEM and combined single-cell heatmap outputs
- document usage and outputs in README

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a1a1a9a48324b53e7dd0556ac69f