### PR TITLE
Extend IntTau gradient script for multi-group folders

### DIFF
--- a/crypt_to_villus_gradients_from_IntTau.m
+++ b/crypt_to_villus_gradients_from_IntTau.m
@@ -1,12 +1,12 @@
 function crypt_to_villus_gradients_from_IntTau
-%CRYPT_TO_VILLUS_GRADIENTS_FROM_INTTAU Analyze crypt->villus gradients for Int/TauPhase/TauModulation.
-%   Interactively selects CSV files (one row per cell) with required columns:
-%   Int, TauPhase, TauModulation, Xcoord, Ycoord.
-%   The user defines the crypt-to-villus axis by drawing a line on the
-%   scatter plot (crypt end first, villus end second). The function projects all cells
-%   onto this axis, bins the normalized positions, computes pooled mean and
-%   SEM per bin for each metric, and saves a single Prism-like figure with
-%   the three pooled mean ± SEM curves plus a CSV summary of bin statistics.
+%CRYPT_TO_VILLUS_GRADIENTS_FROM_INTTAU Analyze crypt->villus gradients for Int/TauPhase/TauModulation across groups.
+%   Each "group" corresponds to a folder containing CSV files (one row per cell)
+%   with required columns: Int, TauPhase, TauModulation, Xcoord, Ycoord.
+%   For every group, the user defines a crypt-to-villus axis on a scatter plot
+%   (first click = crypt base, second click = villus tip). The function projects
+%   all cells in that group onto the axis, bins normalized positions, computes
+%   per-group mean ± SEM for each metric, and overlays all groups on a combined
+%   Prism-like figure. Group names are taken from folder names.
 %
 %   Output directory: ./output_IntTau/
 %
@@ -19,70 +19,100 @@ smoothSpan = 0.12;       % fraction of bins used for smoothing plotted curves
 
 if ~exist(outFolder,'dir'), mkdir(outFolder); end
 
-%% --------------------- FILE SELECTION ---------------------
-[files, pth] = uigetfile('*.csv','Select CSV files','MultiSelect','on');
-if isequal(files,0)
-    % user cancelled
+%% --------------------- GROUP (FOLDER) SELECTION ---------------------
+% Allow the user to select one or more folders. Each folder = one group.
+% If a selected folder contains no CSV files, each of its immediate
+% subfolders is treated as a separate group (facilitating "choose a
+% parent folder to analyze all subfolders" workflows).
+groupDirsInput = selectGroupFolders();
+groupDirs = resolveGroupFolders(groupDirsInput);
+if isempty(groupDirs)
+    disp('No group folders selected. Exiting.');
     return;
 end
-if ischar(files)
-    files = {files};
-end
-fileList = fullfile(pth, files);
 
-%% --------------------- LOAD, VALIDATE, AND GET AXIS PER FILE ---------------------
+groupStruct = struct('Name',{},'Table',{},'BinIdx',{},'Stats',{});
 requiredVars = {'Int','TauPhase','TauModulation','Xcoord','Ycoord'};
-allRows = table();
-for k = 1:numel(fileList)
-    fpath = fileList{k};
-    T = readtable(fpath);
-    assert(all(ismember(requiredVars, T.Properties.VariableNames)), ...
-        'File %s must contain columns: %s', fpath, strjoin(requiredVars, ', '));
-    [~,fname,ext] = fileparts(fpath);
-    sampleName = string([fname ext]);
 
-    % Ask the user to draw the crypt-to-villus axis for this sample.
-    [baseXY, tipXY] = getAxisFromLine(T.Xcoord, T.Ycoord, sampleName);
+%% --------------------- LOAD DATA & DEFINE AXIS PER GROUP ---------------------
+for g = 1:numel(groupDirs)
+    grpDir = groupDirs{g};
+    [~, grpName] = fileparts(grpDir);
+
+    csvList = dir(fullfile(grpDir, '*.csv'));
+    if isempty(csvList)
+        warning('No CSV files found in folder %s. Skipping.', grpDir);
+        continue;
+    end
+
+    grpTable = table();
+    for k = 1:numel(csvList)
+        fpath = fullfile(grpDir, csvList(k).name);
+        T = readtable(fpath);
+        assert(all(ismember(requiredVars, T.Properties.VariableNames)), ...
+            'File %s must contain columns: %s', fpath, strjoin(requiredVars, ', '));
+        T.SourceFile = repmat(string(csvList(k).name), height(T), 1);
+        T.Group = repmat(string(grpName), height(T), 1);
+        grpTable = [grpTable; T]; %#ok<AGROW>
+    end
+
+    if isempty(grpTable)
+        warning('No data loaded for group %s. Skipping.', grpName);
+        continue;
+    end
+
+    % Axis definition per group (same logic as original single-group code).
+    [baseXY, tipXY] = getAxisFromLine(grpTable.Xcoord, grpTable.Ycoord, grpName);
     v = tipXY - baseXY;
     vlen2 = sum(v.^2);
-    assert(vlen2 > 0, 'Crypt and villus clicks are identical for sample %s.', sampleName);
+    assert(vlen2 > 0, 'Crypt and villus clicks are identical for group %s.', grpName);
 
-    pts = [T.Xcoord, T.Ycoord];
-    proj = ((pts - baseXY) * v.') / vlen2; % projection scalar
-    T.Pos01 = min(max(proj,0),1);          % clip to [0,1]
+    % Project and clip to [0,1].
+    pts = [grpTable.Xcoord, grpTable.Ycoord];
+    proj = ((pts - baseXY) * v.') / vlen2;
+    grpTable.Pos01 = min(max(proj,0),1);
 
-    T.Sample = repmat(sampleName, height(T), 1);
-    allRows = [allRows; T]; %#ok<AGROW>
+    groupStruct(end+1).Name = grpName; %#ok<AGROW>
+    groupStruct(end).Table = grpTable;
 end
 
-if isempty(allRows)
-    disp('No data loaded. Exiting.');
+if isempty(groupStruct)
+    disp('No valid group data found. Exiting.');
     return;
 end
 
-%% --------------------- BINNING ---------------------
+%% --------------------- BINNING & GROUP-WISE STATISTICS ---------------------
 edges = linspace(0,1,numBins+1);
 binCenters = edges(1:end-1) + diff(edges)/2;
-[~,~,binIdx] = histcounts(allRows.Pos01, edges);
-
 metrics = {'Int','TauPhase','TauModulation'};
-stats = struct();
-for i = 1:numel(metrics)
-    stats.(metrics{i}) = computeBinStats(allRows.(metrics{i}), binIdx, numBins);
+
+summaryRows = table();
+for g = 1:numel(groupStruct)
+    grpTable = groupStruct(g).Table;
+    [~,~,binIdx] = histcounts(grpTable.Pos01, edges);
+    groupStruct(g).BinIdx = binIdx;
+
+    stats = struct();
+    for i = 1:numel(metrics)
+        stats.(metrics{i}) = computeBinStats(grpTable.(metrics{i}), binIdx, numBins);
+    end
+    groupStruct(g).Stats = stats;
+
+    % Assemble per-bin summary for CSV output.
+    grpCol = repmat(string(groupStruct(g).Name), numBins, 1);
+    summaryRows = [summaryRows; table(grpCol, (1:numBins).', binCenters(:), ...
+        stats.Int.N(:), stats.Int.Mean(:), stats.Int.SEM(:), ...
+        stats.TauPhase.N(:), stats.TauPhase.Mean(:), stats.TauPhase.SEM(:), ...
+        stats.TauModulation.N(:), stats.TauModulation.Mean(:), stats.TauModulation.SEM(:), ...
+        'VariableNames', {'Group','Bin','BinCenter', ...
+        'N_Int','Mean_Int','SEM_Int', ...
+        'N_TauPhase','Mean_TauPhase','SEM_TauPhase', ...
+        'N_TauModulation','Mean_TauModulation','SEM_TauModulation'})]; %#ok<AGROW>
 end
 
-%% --------------------- CSV SUMMARY ---------------------
-summaryTbl = table((1:numBins).', binCenters(:), ...
-    stats.Int.N(:), stats.Int.Mean(:), stats.Int.SEM(:), ...
-    stats.TauPhase.N(:), stats.TauPhase.Mean(:), stats.TauPhase.SEM(:), ...
-    stats.TauModulation.N(:), stats.TauModulation.Mean(:), stats.TauModulation.SEM(:), ...
-    'VariableNames', {'Bin','BinCenter', ...
-    'N_Int','Mean_Int','SEM_Int', ...
-    'N_TauPhase','Mean_TauPhase','SEM_TauPhase', ...
-    'N_TauModulation','Mean_TauModulation','SEM_TauModulation'});
-writetable(summaryTbl, fullfile(outFolder, 'pooled_bin_summary.csv'));
+writetable(summaryRows, fullfile(outFolder, 'grouped_bin_summary.csv'));
 
-%% --------------------- PLOT MEAN ± SEM ---------------------
+%% --------------------- PLOT MULTI-GROUP MEAN ± SEM ---------------------
 fFig = figure('Color','w','Position',[200 200 1200 500]);
 set(fFig,'DefaultAxesFontName','Arial', ...
          'DefaultAxesFontSize',12, ...
@@ -91,32 +121,99 @@ set(fFig,'DefaultAxesFontName','Arial', ...
          'DefaultAxesTickDir','out', ...
          'DefaultAxesBox','off');
 
-ylabs = {'Intensity (a.u.)','TauPhase (ns)','TauModulation (ns)'};
+colors = lines(numel(groupStruct));
+ylabels = {'Intensity (a.u.)','TauPhase (ns)','TauModulation (ns)'};
+
 for i = 1:numel(metrics)
     ax = subplot(1,3,i,'Parent',fFig); hold(ax,'on'); box(ax,'off');
-    mRaw = stats.(metrics{i}).Mean;
-    sRaw = stats.(metrics{i}).SEM;
-    % Smooth only for visualization; CSV retains the raw bin statistics.
-    m = smoothForPlot(mRaw, smoothSpan);
-    s = smoothForPlot(sRaw, smoothSpan);
-    fill(ax, [binCenters fliplr(binCenters)], [m-s; flipud(m+s)].', ...
-        [0 0 0], 'FaceAlpha',0.15, 'EdgeColor','none');
-    plot(ax, binCenters, m, 'k-', 'LineWidth',2);
+    for g = 1:numel(groupStruct)
+        mRaw = groupStruct(g).Stats.(metrics{i}).Mean;
+        sRaw = groupStruct(g).Stats.(metrics{i}).SEM;
+        % Smooth only for visualization; CSV retains raw bin statistics.
+        m = smoothForPlot(mRaw, smoothSpan);
+        s = smoothForPlot(sRaw, smoothSpan);
+        c = colors(g,:);
+        fill(ax, [binCenters fliplr(binCenters)], [m-s; flipud(m+s)].', ...
+            c, 'FaceAlpha',0.15, 'EdgeColor','none');
+        plot(ax, binCenters, m, 'Color', c, 'LineWidth', 2, 'DisplayName', groupStruct(g).Name);
+    end
     xlabel(ax, 'Normalized position (0 = crypt, 1 = villus)');
-    ylabel(ax, ylabs{i});
-    title(ax, sprintf('Pooled %s mean \pm SEM', metrics{i}), 'Interpreter','none');
+    ylabel(ax, ylabels{i});
+    title(ax, sprintf('%s mean \pm SEM', metrics{i}), 'Interpreter','none');
     xlim(ax,[0 1]);
+    legend(ax,'Location','best','Box','off');
 end
 
 try
-    exportgraphics(fFig, fullfile(outFolder,'pooled_mean_sem.png'), 'Resolution', 600);
+    exportgraphics(fFig, fullfile(outFolder,'grouped_mean_sem.png'), 'Resolution', 600);
 catch
-    print(fFig, fullfile(outFolder,'pooled_mean_sem.png'), '-dpng','-r600');
+    print(fFig, fullfile(outFolder,'grouped_mean_sem.png'), '-dpng','-r600');
 end
 
 end
 
 %% --------------------- HELPERS ---------------------
+function folders = selectGroupFolders()
+%SELECTGROUPFOLDERS Let the user choose one or more folders as groups.
+%   Uses repeated UIGETDIR calls so users can pick any set of folders. The
+%   loop ends when the user cancels the dialog.
+    folders = {};
+    while true
+        pth = uigetdir(pwd, 'Select a folder containing CSV files for one group');
+        if isequal(pth,0)
+            break;
+        end
+        folders{end+1} = pth; %#ok<AGROW>
+        choice = questdlg('Add another group folder?', 'Select groups', ...
+            'Yes','No','No');
+        if isempty(choice) || strcmpi(choice,'No')
+            break;
+        end
+    end
+    folders = unique(folders, 'stable');
+end
+
+function folders = resolveGroupFolders(inputDirs)
+%RESOLVEGROUPFOLDERS Expand selected folders into actual group folders.
+%   If a selected folder contains CSV files, it is treated as one group.
+%   Otherwise, each immediate subfolder that contains CSV files becomes a
+%   group. This mirrors "select parent folder to analyze all subfolders".
+    folders = {};
+    if nargin == 0 || isempty(inputDirs)
+        return;
+    end
+    for i = 1:numel(inputDirs)
+        p = inputDirs{i};
+        if ~isfolder(p)
+            warning('Path %s is not a folder. Skipping.', p);
+            continue;
+        end
+
+        csvHere = dir(fullfile(p, '*.csv'));
+        if ~isempty(csvHere)
+            folders{end+1} = p; %#ok<AGROW>
+            continue;
+        end
+
+        % No CSVs in the selected folder; look one level down.
+        subDirs = dir(p);
+        subDirs = subDirs([subDirs.isdir]);
+        subDirs = subDirs(~ismember({subDirs.name}, {'.','..'}));
+        added = false;
+        for s = 1:numel(subDirs)
+            subPath = fullfile(p, subDirs(s).name);
+            if ~isempty(dir(fullfile(subPath, '*.csv')))
+                folders{end+1} = subPath; %#ok<AGROW>
+                added = true;
+            end
+        end
+        if ~added
+            warning('No CSV files found in %s or its immediate subfolders.', p);
+        end
+    end
+    folders = unique(folders, 'stable');
+end
+
 function S = computeBinStats(values, binIdx, numBins)
 %COMPUTEBINSTATS Compute N, mean, and SEM per bin for a vector of values.
     Mean = nan(numBins,1);
@@ -135,13 +232,13 @@ function S = computeBinStats(values, binIdx, numBins)
     S = struct('Mean',Mean,'SEM',SEM,'N',N);
 end
 
-function [baseXY, tipXY] = getAxisFromLine(x, y, sampleName)
+function [baseXY, tipXY] = getAxisFromLine(x, y, groupName)
 %GETAXISFROMLINE Ask the user to draw the crypt-to-villus axis on a scatter plot.
     fScatter = figure('Color','w');
     scatter(x, y, 8, 'k', 'filled');
     axis equal;
     xlabel('Xcoord'); ylabel('Ycoord');
-    title(sprintf('%s: draw axis (crypt base to villus tip)', sampleName), ...
+    title(sprintf('%s: draw axis (crypt base to villus tip)', groupName), ...
         'Interpreter','none');
     set(gca,'FontName','Arial','FontWeight','bold','LineWidth',2,'TickDir','out');
 
@@ -157,11 +254,11 @@ function [baseXY, tipXY] = getAxisFromLine(x, y, sampleName)
             [xClick,yClick] = ginput(2);
         catch
             close(fScatter);
-            error('Axis selection aborted for sample %s.', sampleName);
+            error('Axis selection aborted for group %s.', groupName);
         end
         if numel(xClick) < 2
             close(fScatter);
-            error('Two points are required to define the axis for sample %s.', sampleName);
+            error('Two points are required to define the axis for group %s.', groupName);
         end
         pos = [xClick(:), yClick(:)];
     end


### PR DESCRIPTION
## Summary
- allow selecting multiple group folders (or a parent folder with CSV-containing subfolders) as groups for Int/Tau analysis
- project group cells onto per-group crypt→villus axes, bin positions, and overlay multi-group mean ± SEM plots for Int, TauPhase, and TauModulation
- export grouped bin statistics to a consolidated CSV alongside the combined figure output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693018d5262483248c106838e9f86c24)