### PR TITLE
Improve SEM shading visibility

### DIFF
--- a/crypt_to_villus_gradients_from_IntTau.m
+++ b/crypt_to_villus_gradients_from_IntTau.m
@@ -22,9 +22,13 @@ function crypt_to_villus_gradients_from_IntTau
 %   This function relies only on base MATLAB (R2021b+).
 
 %% --------------------- USER SETTINGS ---------------------
-numBins    = 50;         % number of bins between crypt (0) and villus (1)
-outFolder  = './output_IntTau';
-smoothSpan = 0.12;       % fraction of bins used for smoothing plotted curves
+numBins        = 50;         % number of bins between crypt (0) and villus (1)
+outFolder      = './output_IntTau';
+smoothSpan     = 0.12;       % fraction of bins used for smoothing plotted curves
+semFillAlpha   = 0.35;       % opacity of SEM shading (higher = more visible)
+semEdgeAlpha   = 0.9;        % opacity of SEM outline to further emphasize SEM
+semEdgeLineWid = 1.2;        % line width of SEM outline
+semDisplayScale= 2.0;        % multiply SEM for plotting (e.g., 2 or 3 for clearer ribbons)
 
 if ~exist(outFolder,'dir'), mkdir(outFolder); end
 
@@ -141,12 +145,14 @@ for i = 1:numel(metrics)
     for g = 1:numel(groupStruct)
         mRaw = groupStruct(g).Stats.(metrics{i}).Mean;
         sRaw = groupStruct(g).Stats.(metrics{i}).SEM;
+        sScaled = sRaw * semDisplayScale; % widen SEM visually without altering saved stats
         % Smooth only for visualization; CSV retains raw bin statistics.
         m = smoothForPlot(mRaw, smoothSpan);
-        s = smoothForPlot(sRaw, smoothSpan);
+        s = smoothForPlot(sScaled, smoothSpan);
         c = colors(g,:);
         fill(ax, [binCenters fliplr(binCenters)], [m-s; flipud(m+s)].', ...
-            c, 'FaceAlpha',0.15, 'EdgeColor','none');
+            c, 'FaceAlpha',semFillAlpha, 'EdgeColor',c, ...
+            'EdgeAlpha',semEdgeAlpha, 'LineWidth', semEdgeLineWid);
         plot(ax, binCenters, m, 'Color', c, 'LineWidth', 2, 'DisplayName', groupStruct(g).Name);
     end
     xlabel(ax, 'Normalized position (0 = crypt, 1 = villus)');
@@ -246,6 +252,7 @@ end
 
 function [baseXY, tipXY] = getAxisFromLine(x, y, groupName)
 %GETAXISFROMLINE Ask the user to draw the crypt-to-villus axis on a scatter plot.
+    labelStr = sprintf('Axis selection: %s', groupName);
     fScatter = figure('Color','w', 'Name', labelStr, 'NumberTitle','off');
     scatter(x, y, 8, 'k', 'filled');
     axis equal;


### PR DESCRIPTION
## Summary
- add user-controllable SEM shading opacity and outline options for clearer SEM visibility
- add a plotting-time SEM scaling factor (e.g., 2–3×) to make ribbons more apparent without changing saved statistics

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930237b13fc8324ac9cd954f53495bb)